### PR TITLE
Commented YAML and put version on one line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
+# Disable sudo to speed up the build
 sudo: false
 
+# Set the build language to Python
 language: python
 
-python:
-  - 2.7
+# Set the python version to 2.7
+python: 2.7
 
+# Install the codecov pip dependency
 install:
   - pip install codecov
 
+# Run the unit test
 script:
   - coverage run tests.py
 
+# Push the results back to codecov
 after_success:
   - codecov


### PR DESCRIPTION
The following changes have been made:
- Each part of the Travis YAML file is commented
- The Python version specifier in the Travis YAML file now only takes up a single line