### PR TITLE
Codecov expects the coverage in xml format

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ coverage run tests.py
 #### pytest
 ```
 pip install pytest-cov
-pytest --cov=./
+pytest --cov=./ --cov-report=xml
 ```
 #### nosetests
 ```

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ source=your_package_name
 ```
 pip install coverage
 coverage run tests.py
+coverage xml
 ```
 #### pytest
 ```


### PR DESCRIPTION
get `coverage` and `pytest-cov` to produce the right coverage report format for `codecov/codecov-action@v2`