### PR TITLE
Keep GitHub Actions up to date with GitHub's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,11 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  groups:
+    github-actions:
+      patterns:
+        - "*"  # Group all Actions updates into a single larger pull request
+  schedule:
+    interval: weekly


### PR DESCRIPTION
The examples are less helpful when the GitHub Actions are out of date.
* [Keeping your software supply chain secure with Dependabot](https://docs.github.com/en/code-security/dependabot)
* [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)
* [Configuration options for the `dependabot.yml` file - package-ecosystem](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)

To see all GitHub Actions dependencies, type:
% `git grep 'uses: ' .github/workflows/`
```
.github/workflows/ci.yml:        uses: actions/checkout@v4
.github/workflows/ci.yml:        uses: actions/setup-python@v4
.github/workflows/ci.yml:        uses: codecov/test-results-action@v1
.github/workflows/ci.yml:        uses: codecov/codecov-action@main
.github/workflows/ci.yml:        uses: codecov/codecov-action@main
.github/workflows/ci.yml:        uses: codecov/codecov-action@main
.github/workflows/ci.yml:        uses: codecov/codecov-action@main
.github/workflows/enforce-license-compliance.yml:        uses: getsentry/action-enforce-license-compliance@57ba820387a1a9315a46115ee276b2968da51f3d # main
```